### PR TITLE
Ivpy path

### DIFF
--- a/notebooks/data-explorations/data-exploration-12.ipynb
+++ b/notebooks/data-explorations/data-exploration-12.ipynb
@@ -25,7 +25,7 @@
    "outputs": [],
    "source": [
     "import sys\n",
-    "sys.path.append(\"/home/richard/Notebooks/2020/Ivpy/ivpy/src\")"
+    "sys.path.append(\"/srv/explore-the-collections/code/ivpy/src\")"
    ]
   },
   {

--- a/notebooks/data-explorations/data-exploration-14.ipynb
+++ b/notebooks/data-explorations/data-exploration-14.ipynb
@@ -19,7 +19,7 @@
    "outputs": [],
    "source": [
     "import sys\n",
-    "sys.path.append(\"/home/richard/Notebooks/2020/Ivpy/ivpy/src/\")"
+    "sys.path.append(\"/srv/explore-the-collections/code/ivpy/src\")"
    ]
   },
   {

--- a/notebooks/data-explorations/intro.md
+++ b/notebooks/data-explorations/intro.md
@@ -10,10 +10,10 @@ The site's technical build uses:
   * [Jupyter Book](jupyterbook.org/)
   * [Pandas](pandas.pydata.org/)
   * [Altair](altair-viz.github.io/)
-  * [Ivpy](https://github.com/damoncrockett/ivpy)
+  * [A modified version of Ivpy](https://github.com/atiro/ivpy)
   * [Python](https://www.python.org/)
   * and various other libraries mentioned in individual explorations.
-  
+
 and the examples feature the collections data and images of the [V&A](https://www.vam.ac.uk) and:
   * [National Library of Scotland, Edinburgh](https://nls.uk) (Exploration 1)
   * [Art Institute of Chicago, Chicago](https://artic.edu/) (Exploration 2)


### PR DESCRIPTION
I had some problems setting up Ivpy, so here are some small changes to try to make this easier for others. I've standardised the path that the sys module uses on the data-explorations, however it will need to be changed for individual users, and I have also linked the modified ivpy repository instead of the original module, because it needs to read from a URL for these notebooks.