### PR TITLE
Paris in spring

### DIFF
--- a/notebooks/data-explorations/data-exploration-12.ipynb
+++ b/notebooks/data-explorations/data-exploration-12.ipynb
@@ -655,10 +655,6 @@
     }
    ],
    "source": [
-    "#import urllib3\n",
-    "#import requests\n",
-    "import pandas as pd\n",
-    "\n",
     "df_louvre_printemps = pd.read_csv(\"louvre-spring.csv\", sep=\";\")\n",
     "df_louvre_printemps.head(15)"
    ]
@@ -679,7 +675,6 @@
    "outputs": [],
    "source": [
     "import lineup_widget\n",
-    "import pandas as pd\n",
     "\n",
     "w = lineup_widget.LineUpWidget(df_louvre_printemps)\n",
     "w.on_selection_changed(lambda selection: print(selection))\n",
@@ -725,6 +720,159 @@
    "metadata": {},
    "source": [
     "and you can see the Louvre version (a copy after the engraving by David Lucas) on [their website](https://collections.louvre.fr/en/ark:/53355/cl010063018)."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Visualising the Louvre's data\n",
+    "\n",
+    "So far we have the metadata of the image but no way to retrieve the image, so lets try to fix that. If we look at the URL of the record of the image we can see that it is a set string followed by the ARK: https://collections.louvre.fr/en/ark:/53355/cl010063018. On this page there are multiple images, but lets assume we are only interested in the first one:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "Image(url = \"https://collections.louvre.fr/en/artwork/image/download/39904/87414\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The beginning of the URL is the same for every image, it is only the path at the end that we are interested in. If we begin looking through the html we can find the image has an attribute of \"data-api-dl\" which is the path that we need. So let's start by loading in the URL using the requests module."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import requests\n",
+    "site_url = \"https://collections.louvre.fr/en/ark:/53355/cl010063018\"\n",
+    "\n",
+    "response = requests.get(site_url)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Now let's use beautiful soup to parse the HTML and extract the image download path"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from bs4 import BeautifulSoup\n",
+    "\n",
+    "response = response.content\n",
+    "imagePaths = []\n",
+    "\n",
+    "soup = BeautifulSoup(response)\n",
+    "\n",
+    "for p in soup.findAll('picture'):\n",
+    "    image = p.find_all('img')\n",
+    "    imagePaths.append(image[0]['data-api-dl'])\n",
+    "\n",
+    "print(imagePaths[0])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Now we have retrieved the download code of this image we can append it to the begging of the URL and display the image:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "Image(url = \"https://collections.louvre.fr\" + imagePaths[0])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Colour comparison\n",
+    "\n",
+    "Let's compare the colour scheme between the images. Lets start by finding the average pixel colour of the V&A's version of the image. We will use a module called cv2 to do this, but first we need to conert the image into a numpy array using pillow."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import cv2, numpy as np\n",
+    "from sklearn.cluster import KMeans\n",
+    "from skimage import io\n",
+    "from PIL import Image\n",
+    "\n",
+    "imageUrls = ['https://framemark.vam.ac.uk/collections/2006BC6067/full/600,/0/default.jpg', 'https://collections.louvre.fr/en/artwork/image/download/39904/87414']\n",
+    "\n",
+    "def visualize_colors(cluster, centroids):\n",
+    "    # Get the number of different clusters, create histogram, and normalize\n",
+    "    labels = np.arange(0, len(np.unique(cluster.labels_)) + 1)\n",
+    "    (hist, _) = np.histogram(cluster.labels_, bins = labels)\n",
+    "    hist = hist.astype(\"float\")\n",
+    "    hist /= hist.sum()\n",
+    "\n",
+    "    # Create frequency rect and iterate through each cluster's color and percentage\n",
+    "    rect = np.zeros((50, 300, 3), dtype=np.uint8)\n",
+    "    colors = sorted([(percent, color) for (percent, color) in zip(hist, centroids)])\n",
+    "    start = 0\n",
+    "    for (percent, color) in colors:\n",
+    "        #print(color, \"{:0.2f}%\".format(percent * 100))\n",
+    "        end = start + (percent * 300)\n",
+    "        cv2.rectangle(rect, (int(start), 0), (int(end), 50), \\\n",
+    "                      color.astype(\"uint8\").tolist(), -1)\n",
+    "        start = end\n",
+    "    return rect\n",
+    "    \n",
+    "# Load image and convert to a list of pixels\n",
+    "image = io.imread(imageUrls[0])\n",
+    "image = cv2.cvtColor(image, cv2.COLOR_BGR2RGB)\n",
+    "reshape = image.reshape((image.shape[0] * image.shape[1], 3))\n",
+    "\n",
+    "# Find and display most dominant colors\n",
+    "cluster = KMeans(n_clusters=10).fit(reshape)\n",
+    "visualize = visualize_colors(cluster, cluster.cluster_centers_)\n",
+    "visualize = cv2.cvtColor(visualize, cv2.COLOR_BGR2RGB)\n",
+    "\n",
+    "Image.fromarray(visualize)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Load image and convert to a list of pixels\n",
+    "image = io.imread(imageUrls[1])\n",
+    "image = cv2.cvtColor(image, cv2.COLOR_BGR2RGB)\n",
+    "reshape = image.reshape((image.shape[0] * image.shape[1], 3))\n",
+    "\n",
+    "# Find and display most dominant colors\n",
+    "cluster = KMeans(n_clusters=10).fit(reshape)\n",
+    "visualize = visualize_colors(cluster, cluster.cluster_centers_)\n",
+    "visualize = cv2.cvtColor(visualize, cv2.COLOR_BGR2RGB)\n",
+    "\n",
+    "Image.fromarray(visualize)"
    ]
   },
   {

--- a/notebooks/data-explorations/requirements.txt
+++ b/notebooks/data-explorations/requirements.txt
@@ -5,4 +5,5 @@ ghp-import
 pandas
 bokeh
 altair
-
+lineup_widget
+opencv-python


### PR DESCRIPTION
My plan is to compare the colour pallets of the spring pictures in the Louvre and the spring images in the V&A. I started off by scraping the HTML from a Louvre website, using the ARK code of an item and beautiful soup. I then used Open CV to do an image comparison of the two images, by creating a colour palette based off of the main pixel colours used in an image. The next thing I would do is find some more interesting images to compare, and draw a conclusion over which image contains the nicest variety of colours. I also cleaned up some of the code, e.g. removing the lines of code with reimport panda multiple times.

Is this a direction that you think would work well for this page, or would you rather I focus on the metadata of the images and how that compares. Another question I have is how the Louvre's copyright policy relates to the displaying of images on this sight, and wether I should try to avoid displaying the Louvre's images.