### PR TITLE
Edit api-book/requirements.txt to resolve compatibility issues with Python versions >= 3.10

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ notebooks/data-explorations/_build/**
 *.swp
 **/.ipynb_checkpoints/**
 **/.ipynb_checkpoints-old/**
+**/.venv

--- a/api-book/requirements.txt
+++ b/api-book/requirements.txt
@@ -52,14 +52,13 @@ nest-asyncio==1.5.1
 nested-lookup==0.2.21
 nodeenv==1.5.0
 notebook==6.2.0
-numpy==1.19.5
+numpy>=1.19.5
 packaging==20.9
 pandas==1.1.5
 pandocfilters==1.4.3
 parso==0.8.1
 pexpect==4.8.0
 pickleshare==0.7.5
-pkg-resources==0.0.0
 plotly==4.14.3
 prometheus-client==0.9.0
 prompt-toolkit==3.0.14
@@ -73,7 +72,7 @@ pyparsing==2.4.7
 pyrsistent==0.17.3
 python-dateutil==2.8.1
 pytz==2021.1
-PyYAML==5.4.1
+PyYAML>=5.4.1
 pyzmq==22.0.2
 requests==2.25.1
 retrying==1.3.3


### PR DESCRIPTION
This PR addresses Issue #51, using the three resolutions listed there.

- In `requirements.txt` the two versioning changes to `PyYAML` and `numpy` use `>=` syntax. I don't know if this introduces any risk of backward compatibility issues (I'm not a regular Python user, sorry).
- The addition in `.gitignore` is to ignore my `venv` directory.